### PR TITLE
Show tooltip on large numbers

### DIFF
--- a/src/webapp/features/analytics/dashboard/TopNChart.tsx
+++ b/src/webapp/features/analytics/dashboard/TopNChart.tsx
@@ -6,6 +6,7 @@ import { ErrorState } from "@components/ErrorState";
 import { formatNumber } from "@fns/format-number";
 import { useLocalStorage } from "@hooks/use-localstorage";
 import { twMerge } from "tailwind-merge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@components/Tooltip";
 
 type Item = {
   name: string;
@@ -107,7 +108,16 @@ function TopNRow(props: TopNRowProps) {
         <div className="flex z-10">{props.children}</div>
       </div>
       <p className="text-sm pr-2 z-10 tabular-nums">
-        {props.format === "percentage" ? `${Math.round(props.percentage * 100)}%` : formatNumber(props.item.value)}
+        {props.format === "percentage" ? (
+          `${Math.round(props.percentage * 100)}%`
+        ) : (
+          <TooltipProvider>
+            <Tooltip>
+              {props.item.value >= 1e3 ? <TooltipContent>{props.item.value}</TooltipContent> : undefined}
+              <TooltipTrigger>{formatNumber(props.item.value)}</TooltipTrigger>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </p>
     </div>
   );

--- a/src/webapp/features/analytics/dashboard/TopNChart.tsx
+++ b/src/webapp/features/analytics/dashboard/TopNChart.tsx
@@ -111,7 +111,7 @@ function TopNRow(props: TopNRowProps) {
         {props.format === "percentage" ? (
           `${Math.round(props.percentage * 100)}%`
         ) : props.item.value >= 1e3 ? (
-          <TooltipProvider>
+          <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipContent>{props.item.value}</TooltipContent>
               <TooltipTrigger>{formatNumber(props.item.value)}</TooltipTrigger>

--- a/src/webapp/features/analytics/dashboard/TopNChart.tsx
+++ b/src/webapp/features/analytics/dashboard/TopNChart.tsx
@@ -110,13 +110,15 @@ function TopNRow(props: TopNRowProps) {
       <p className="text-sm pr-2 z-10 tabular-nums">
         {props.format === "percentage" ? (
           `${Math.round(props.percentage * 100)}%`
-        ) : (
+        ) : props.item.value >= 1e3 ? (
           <TooltipProvider>
             <Tooltip>
-              {props.item.value >= 1e3 ? <TooltipContent>{props.item.value}</TooltipContent> : undefined}
+              <TooltipContent>{props.item.value}</TooltipContent>
               <TooltipTrigger>{formatNumber(props.item.value)}</TooltipTrigger>
             </Tooltip>
           </TooltipProvider>
+        ) : (
+          props.item.value
         )}
       </p>
     </div>


### PR DESCRIPTION
# :dizzy: Changelog
:star: Fixes #67 
:star: Show tooltip on large numbers (>=1e3) in dashboard