### PR TITLE
Dashboard Metrics: Render tooltip on hover for numbers >=1000

### DIFF
--- a/src/webapp/features/analytics/key_metrics/Metric.tsx
+++ b/src/webapp/features/analytics/key_metrics/Metric.tsx
@@ -1,4 +1,5 @@
 import { GrowthIndicator } from "@components/GrowthIndicator";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@components/Tooltip";
 import { formatNumber } from "@fns/format-number";
 import { twJoin, twMerge } from "tailwind-merge";
 
@@ -15,6 +16,15 @@ type Props = {
 export function Metric(props: Props) {
   const Container = props.onClick ? "button" : "div";
 
+  const TooltipOnOverflow = (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipContent>{props.current}</TooltipContent>
+        <TooltipTrigger>{formatNumber(props.current, props.format)}</TooltipTrigger>
+      </Tooltip>
+    </TooltipProvider>
+  );
+
   return (
     <Container
       className={twJoin(
@@ -24,26 +34,19 @@ export function Metric(props: Props) {
       onClick={props.onClick}
     >
       <div className="text-2xl font-semibold w-full">
-        {formatNumber(props.current, props.format)}
+        {props.format === "number" && props.current >= 1e3
+          ? TooltipOnOverflow
+          : formatNumber(props.current, props.format)}
       </div>
       <div className="text-sm text-muted-foreground w-full">
         {props.label}{" "}
-        <div
-          className={twMerge(
-            "ml-1 p-1 inline-block rounded",
-            props.activeClassName,
-            !props.active && "hidden"
-          )}
-        />
+        <div className={twMerge("ml-1 p-1 inline-block rounded", props.activeClassName, !props.active && "hidden")} />
       </div>
       <GrowthIndicator
         className="mt-1 w-full"
         current={props.current}
         previous={props.previous}
-        previousFormatted={`${formatNumber(
-          props.previous ?? 0,
-          props.format
-        )} ${props.label.toLowerCase()}`}
+        previousFormatted={`${formatNumber(props.previous ?? 0, props.format)} ${props.label.toLowerCase()}`}
       />
     </Container>
   );


### PR DESCRIPTION
# :dizzy: Changelog
:star: Fixes #67 
:star: Show tooltip with unformatted value on hover for numbers `>=1000`.
![aptabase](https://github.com/aptabase/aptabase/assets/22348265/51ea2088-80b2-4662-a4fa-af88967aa036)
NOTE: tooltip will not be shown for numbers less than 1000, the above snapshot is for demonstration purposes only. 