### PR TITLE
Disable signup #64

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "always"
   },
   "csharp.format.enable": true,
   "editor.tabSize": 2,

--- a/src/Features/Authentication/AuthService.cs
+++ b/src/Features/Authentication/AuthService.cs
@@ -67,6 +67,9 @@ public class AuthService : IAuthService
 
     public async Task SendRegisterEmailAsync(string name, string email, CancellationToken cancellationToken)
     {
+        if (_env.DisableSignup) // Not throwing if someone just bypassed the ui to try to register, make them question if it worked or not
+            return;
+
         var user = await FindUserByEmailAsync(email, cancellationToken);
         if (user != null)
         {
@@ -85,6 +88,9 @@ public class AuthService : IAuthService
 
     public async Task<UserAccount> CreateAccountAsync(string name, string email, CancellationToken cancellationToken)
     {
+        if (_env.DisableSignup) // If we get this low-level it means that oauth failed, so we actually need to throw SOMETHING
+            throw new System.InvalidOperation("Signup disabled");
+
         var userId = NanoId.New();
         var cmd = new CommandDefinition(
             "INSERT INTO users (id, name, email, free_quota) VALUES (@userId, @name, @email, 20000)",

--- a/src/Features/Authentication/AuthService.cs
+++ b/src/Features/Authentication/AuthService.cs
@@ -89,7 +89,7 @@ public class AuthService : IAuthService
     public async Task<UserAccount> CreateAccountAsync(string name, string email, CancellationToken cancellationToken)
     {
         if (_env.DisableSignup) // If we get this low-level it means that oauth failed, so we actually need to throw SOMETHING
-            throw new System.InvalidOperation("Signup disabled");
+            throw new System.InvalidOperationException("Signup disabled");
 
         var userId = NanoId.New();
         var cmd = new CommandDefinition(

--- a/src/Features/Configuration/ConfigController.cs
+++ b/src/Features/Configuration/ConfigController.cs
@@ -20,7 +20,7 @@ public class ConfigController : Controller
     }
 
     [HttpGet("/api/_config")]
-    public async Task<IActionResult> Get(CancellationToken cancellationToken)
+    public IActionResult Get(CancellationToken cancellationToken)
     {
         return Ok(new {
             disableSignup = _env.DisableSignup

--- a/src/Features/Configuration/ConfigController.cs
+++ b/src/Features/Configuration/ConfigController.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Aptabase.Features.Configuration;
+
+[ApiController]
+[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+public class ConfigController : Controller
+{
+    private readonly ILogger _logger;
+    private readonly EnvSettings _env;
+
+    public ConfigController(
+        ILogger<ConfigController> logger,
+        EnvSettings env)
+    {
+        _env = env ?? throw new ArgumentNullException(nameof(env));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [HttpGet("/api/_config")]
+    public async Task<IActionResult> Get(CancellationToken cancellationToken)
+    {
+        return Ok(new {
+            disableSignup = _env.DisableSignup
+        });
+    }
+}

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -34,6 +34,9 @@ public class EnvSettings
     // Variable Name: AUTH_SECRET
     public byte[] AuthSecret { get; private set; } = [];
 
+    // Explicitly disable any kind of sign up, only allowing already registered users to login
+    public bool DisableSignup { get; private set; } = false;
+
     public string? MailCatcherConnectionString { get; private set; }
 
     // The host of the SMTP server
@@ -105,6 +108,7 @@ public class EnvSettings
             LemonSqueezyApiKey = Get("LEMONSQUEEZY_API_KEY"),
             LemonSqueezySigningSecret = Get("LEMONSQUEEZY_SIGNING_SECRET"),
 
+            DisableSignup = Get("DISABLE_SIGNUP", false),
             SmtpHost = Get("SMTP_HOST"),
             SmtpPort = GetInt("SMTP_PORT"),
             SmtpUsername = Get("SMTP_USERNAME"),
@@ -133,17 +137,25 @@ public class EnvSettings
         return Environment.GetEnvironmentVariable(name);
     }
 
-    private static string Get(string name)
+    private static string Get(string name, string defaultValue = "")
     {
-        return Environment.GetEnvironmentVariable(name) ?? "";
+        return Environment.GetEnvironmentVariable(name) ?? defaultValue;
     }
 
-    private static int GetInt(string name)
+    private static int GetInt(string name, int defaultValue = 0)
     {
         var value = Environment.GetEnvironmentVariable(name) ?? "";
         if (int.TryParse(value, out var result))
             return result;
-        return 0;
+        return defaultValue;
+    }
+
+    private static bool GetBool(string name, bool defaultValue = false) 
+    {
+        var value = Environment.GetEnvironmentVariable(name) ?? "";
+        if (bool.TryParse(value, out var result))
+            return result;
+        return defaultValue;
     }
 
     private static string MustGet(string name)

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -108,7 +108,7 @@ public class EnvSettings
             LemonSqueezyApiKey = Get("LEMONSQUEEZY_API_KEY"),
             LemonSqueezySigningSecret = Get("LEMONSQUEEZY_SIGNING_SECRET"),
 
-            DisableSignup = Get("DISABLE_SIGNUP", false),
+            DisableSignup = GetBool("DISABLE_SIGNUP", false),
             SmtpHost = Get("SMTP_HOST"),
             SmtpPort = GetInt("SMTP_PORT"),
             SmtpUsername = Get("SMTP_USERNAME"),

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -19,7 +19,8 @@
       "@fns/*": ["./webapp/fns/*"],
       "@hooks/*": ["./webapp/hooks/*"],
       "@components/*": ["./webapp/components/*"],
-      "@features/*": ["./webapp/features/*"]
+      "@features/*": ["./webapp/features/*"],
+      "@root/*": ["./webapp/*"]
     }
   },
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -66,6 +66,10 @@ export default defineConfig({
         find: "@features",
         replacement: path.resolve(__dirname, "./webapp/features"),
       },
+      {
+        find: "@root",
+        replacement: path.resolve(__dirname, "./webapp"),
+      }
     ],
   },
 });

--- a/src/webapp/config.tsx
+++ b/src/webapp/config.tsx
@@ -1,0 +1,44 @@
+import { createContext, ReactNode, useState, useContext, useEffect } from "react";
+import { api } from "@fns/api";
+
+export type Config = {
+  disableSignup: boolean
+};
+
+export type ConfigContextType = {
+  isLoading: boolean;
+  config: Config;
+  refresh: () => Promise<void>;
+};
+
+const ConfigContext = createContext<ConfigContextType>();
+
+export function ConfigProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<Config>({
+    disableSignup: false
+  });
+  const [configIsLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return <ConfigContext.Provider value={{ config, configIsLoading, refresh }}>{children}</ConfigContext.Provider>;
+  
+  async function refresh() {
+    setIsLoading(true);
+
+    try {
+      const [status, config] = await api.fetch('GET', '/config');
+      setConfig(await config.json());
+    }
+    catch (ex) {
+      console.error(ex);
+    }
+
+    setIsLoading(false);
+  }
+}
+export function useConfig() {
+  return useContext(ConfigContext);
+}

--- a/src/webapp/config.tsx
+++ b/src/webapp/config.tsx
@@ -6,12 +6,18 @@ export type Config = {
 };
 
 export type ConfigContextType = {
-  isLoading: boolean;
+  configIsLoading: boolean;
   config: Config;
   refresh: () => Promise<void>;
 };
 
-const ConfigContext = createContext<ConfigContextType>();
+const ConfigContext = createContext<ConfigContextType>({
+  configIsLoading: false,
+  config: {
+    disableSignup: false
+  },
+  refresh: () => Promise.resolve()
+});
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
   const [config, setConfig] = useState<Config>({
@@ -23,7 +29,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     refresh();
   }, []);
 
-  return <ConfigContext.Provider value={{ config, configIsLoading, refresh }}>{children}</ConfigContext.Provider>;
+  return <ConfigContext.Provider value={{ configIsLoading, config, refresh }}>{children}</ConfigContext.Provider>;
   
   async function refresh() {
     setIsLoading(true);

--- a/src/webapp/config.tsx
+++ b/src/webapp/config.tsx
@@ -35,7 +35,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
 
     try {
-      const [status, config] = await api.fetch('GET', '/config');
+      const [status, config] = await api.fetch('GET', '/_config');
       setConfig(await config.json());
     }
     catch (ex) {

--- a/src/webapp/features/auth/LoginPage.tsx
+++ b/src/webapp/features/auth/LoginPage.tsx
@@ -11,6 +11,7 @@ import { isOAuthEnabled } from "@features/env";
 import { Logo } from "./Logo";
 import { Button } from "@components/Button";
 import { TextInput } from "@components/TextInput";
+import { useConfig } from "@root/config";
 
 type FormStatus = "idle" | "loading" | "success" | "notfound";
 
@@ -18,15 +19,22 @@ type StatusMessageProps = {
   status: FormStatus;
 };
 
-const SignUpMessage = () => (
-  <span className="block">
-    Don't have an account?{" "}
-    <Link className="font-semibold text-foreground" to="/auth/register">
-      Sign up
-    </Link>{" "}
-    for free.
-  </span>
-);
+const SignUpMessage = () => {
+  const { config, configIsLoading } = useConfig();
+  
+  if (configIsLoading || config.DisableSignup)
+    return null;
+
+  return (
+    <span className="block">
+      Don't have an account?{" "}
+      <Link className="font-semibold text-foreground" to="/auth/register">
+        Sign up
+      </Link>{" "}
+      for free.
+    </span>
+  );
+};
 
 const StatusMessage = (props: StatusMessageProps) => {
   if (props.status === "success") {

--- a/src/webapp/features/auth/LoginPage.tsx
+++ b/src/webapp/features/auth/LoginPage.tsx
@@ -20,9 +20,9 @@ type StatusMessageProps = {
 };
 
 const SignUpMessage = () => {
-  const { config, configIsLoading } = useConfig();
+  const { configIsLoading, config } = useConfig();
   
-  if (configIsLoading || config.DisableSignup)
+  if (configIsLoading || config.disableSignup)
     return null;
 
   return (

--- a/src/webapp/main.tsx
+++ b/src/webapp/main.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { initAnalytics } from "./analytics";
+import { ConfigProvider } from "./config";
 import router from "./router";
 
 const queryClient = new QueryClient({
@@ -22,12 +23,14 @@ initAnalytics();
 const root = document.getElementById("root") as HTMLElement;
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <Provider>
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-        </QueryClientProvider>
-      </Provider>
-    </ThemeProvider>
+    <ConfigProvider>
+      <ThemeProvider>
+          <Provider>
+            <QueryClientProvider client={queryClient}>
+              <RouterProvider router={router} />
+            </QueryClientProvider>
+          </Provider>
+      </ThemeProvider>
+    </ConfigProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
This is just a straight up fix for issue #64. It adds the ability to disable signups on an instance by setting the environment variable `DISABLE_SIGNUPS` to `true`.

It disables the underlying APIs if the frontend is bypassed.
It adds the concept of passing a generic `config` object to the frontend via api, which is exposed through a custom context to the rest of the frontend (allowing further ui configuration without having to do specific extra api calls for each part.
It.
It hides the sign up message on the main screen.