### PR TITLE
feat: Add password login for admin account and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+本文件为 Claude Code (claude.ai/code) 在此代码库中工作时提供指导。
+
+## 项目概述
+
+Aptabase 是一个开源的、隐私优先的应用分析平台，适用于移动端、桌面端和 Web 应用，是 Firebase/Google Analytics 的替代方案。
+
+## 技术栈
+
+- **后端**: ASP.NET Core 8.0 (C#)
+- **前端**: React 18 + TypeScript + Vite
+- **数据库**: PostgreSQL（用户数据）+ ClickHouse（分析事件）
+- **样式**: TailwindCSS
+- **状态管理**: Jotai
+- **测试框架**: xUnit
+
+## 开发命令
+
+```bash
+# 启动依赖服务（PostgreSQL、ClickHouse、Mailcatcher）
+docker compose up -d
+
+# 安装依赖
+cd src && npm install && dotnet restore
+
+# 运行开发环境（需要两个终端）
+# 终端 1 - 后端:
+cd src && dotnet watch
+
+# 终端 2 - 前端:
+cd src && npm run dev
+
+# 或使用 Makefile（同时运行两者）:
+make dev
+
+# 运行测试
+dotnet test --project tests/UnitTests
+dotnet test --project tests/IntegrationTests
+
+# 构建前端生产版本
+cd src && npm run build
+```
+
+## 架构
+
+### 后端结构 (`src/Features/`)
+
+采用基于功能的模块化组织，每个领域拥有独立的控制器、查询和服务：
+
+- **Ingestion**: 事件采集管道，带缓冲机制（`InMemoryEventBuffer` → `ClickHouseIngestionClient`）
+- **Stats**: 分析查询和聚合
+- **Authentication**: OAuth 认证（GitHub、Google），基于 Cookie 的会话管理
+- **Billing**: LemonSqueezy 订阅集成
+- **GeoIP**: MaxMind 数据库或云端地理定位
+- **Notification**: 通过 SES、SMTP 或 Mailcatcher（开发环境）发送邮件
+
+### 前端结构 (`src/webapp/`)
+
+- **features/**: 领域特定的页面和组件（analytics、apps、billing、auth）
+- **components/**: 共享 UI 组件
+- **hooks/**: 自定义 React Hooks
+- **atoms/**: Jotai 状态原子
+- **fns/**: 工具函数
+
+### 路径别名（TypeScript）
+
+```typescript
+@components → ./webapp/components
+@features   → ./webapp/features
+@hooks      → ./webapp/hooks
+@fns        → ./webapp/fns
+```
+
+### API 代理配置
+
+前端开发服务器（端口 3000）代理到后端（端口 5251）：
+- `/api/*` → 后端 API 端点
+- `/uploads/*` → Blob 存储
+- `/webhook/*` → Webhook 处理器
+
+## 数据库访问
+
+开发环境凭据（docker-compose）：
+- **PostgreSQL**: `aptabase:aptabase_pw`，端口 5432
+- **ClickHouse**: `aptabase:aptabase_pw`，端口 8123
+- **Mailcatcher UI**: http://localhost:1080
+
+## 关键模式
+
+- **双数据库架构**: PostgreSQL 存储用户/应用元数据，ClickHouse 存储高吞吐量事件分析数据
+- **FluentMigrator**: 数据库迁移位于 `src/Data/Migrations/`
+- **Dapper**: SQL 查询，启用 `MatchNamesWithUnderscores`
+- **速率限制**: 内置策略用于 SignUp、Stats、EventIngestion、FeatureFlags 端点
+- **CORS**: 仪表盘采用限制性策略（`AllowAptabaseCom`），SDK 采集采用宽松策略（`AllowAny`）
+
+## 配置
+
+首次运行前，将 `src/Properties/launchSettings.example.json` 复制为 `launchSettings.json`。环境特定配置位于 `appsettings.{Environment}.json`。
+
+## CI/CD
+
+GitHub Actions 工作流（`.github/workflows/ci.yml`）：
+- 运行单元测试和集成测试
+- 构建多架构 Docker 镜像（amd64/arm64）
+- main 分支推送时发布到 GitHub Container Registry

--- a/docs/EVENT_INGESTION_API.md
+++ b/docs/EVENT_INGESTION_API.md
@@ -1,0 +1,219 @@
+# Aptabase Event Ingestion API
+
+本文档说明如何通过 HTTP API 向 Aptabase 推送分析事件。
+
+## 修订记录
+
+| 版本 | 日期 | 修订内容 | 修订人 |
+|------|------|----------|--------|
+| v1.0 | 2026-01-05 | 初始版本，包含事件推送 API 说明 | AIMO 开发团队 |
+
+## API 端点
+
+```
+POST /api/v0/event
+```
+
+## 请求头
+
+| Header | 必填 | 说明 |
+|--------|------|------|
+| `Content-Type` | 是 | 必须为 `application/json` |
+| `App-Key` | 是 | 应用的 App Key，格式如 `A-DEV-7944693530` |
+
+## 请求体
+
+```json
+{
+  "timestamp": "2026-01-05T08:10:00Z",
+  "sessionId": "unique-session-id",
+  "eventName": "event_name",
+  "systemProps": {
+    "osName": "macOS",
+    "osVersion": "14.0",
+    "locale": "zh-CN",
+    "appVersion": "1.0.0",
+    "appBuildNumber": "1",
+    "sdkVersion": "aptabase-swift@0.3.0"
+  },
+  "props": {
+    "key": "value"
+  }
+}
+```
+
+### 字段说明
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `timestamp` | string | 否 | ISO 8601 格式的 UTC 时间戳，默认为服务器接收时间 |
+| `sessionId` | string | 否 | 会话唯一标识，用于关联同一会话的事件 |
+| `eventName` | string | 是 | 事件名称，如 `app_started`、`button_clicked` |
+| `systemProps` | object | 是 | 系统属性对象 |
+| `props` | object | 否 | 自定义事件属性，键值对形式 |
+
+### systemProps 字段说明
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `osName` | string | 否 | 操作系统名称，如 `macOS`、`iOS`、`Android`、`Windows` |
+| `osVersion` | string | 否 | 操作系统版本，如 `14.0` |
+| `locale` | string | 否 | 语言区域设置，如 `zh-CN`、`en-US` |
+| `appVersion` | string | 否 | 应用版本号，如 `1.0.0` |
+| `appBuildNumber` | string | 否 | 应用构建号，如 `100` |
+| `sdkVersion` | string | 是 | SDK 版本标识，格式为 `sdk-name@version` |
+
+## 响应
+
+### 成功响应
+
+- **状态码**: `200 OK`
+- **响应体**: `{}`
+
+### 错误响应
+
+#### 400 Bad Request - 验证错误
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "SystemProps.SdkVersion": ["The SdkVersion field is required."]
+  }
+}
+```
+
+#### 400 Bad Request - App Key 无效
+
+当 App Key 不存在或无效时，服务器会记录警告日志但仍返回 200 状态码（静默失败）。
+
+## 使用示例
+
+### 基础事件推送
+
+```bash
+curl -X POST "https://your-aptabase-server/api/v0/event" \
+  -H "Content-Type: application/json" \
+  -H "App-Key: A-DEV-7944693530" \
+  -d '{
+    "eventName": "app_started",
+    "systemProps": {
+      "sdkVersion": "curl@1.0"
+    }
+  }'
+```
+
+### 完整事件推送
+
+```bash
+curl -X POST "https://your-aptabase-server/api/v0/event" \
+  -H "Content-Type: application/json" \
+  -H "App-Key: A-DEV-7944693530" \
+  -d '{
+    "timestamp": "2026-01-05T08:10:00Z",
+    "sessionId": "session-abc123",
+    "eventName": "button_clicked",
+    "systemProps": {
+      "osName": "macOS",
+      "osVersion": "14.0",
+      "locale": "zh-CN",
+      "appVersion": "1.0.0",
+      "appBuildNumber": "100",
+      "sdkVersion": "aptabase-swift@0.3.0"
+    },
+    "props": {
+      "button_name": "submit",
+      "page": "checkout",
+      "value": 99.99
+    }
+  }'
+```
+
+### 本地开发环境
+
+本地开发时使用 HTTPS 且忽略证书验证：
+
+```bash
+curl -k -X POST "https://localhost:5251/api/v0/event" \
+  -H "Content-Type: application/json" \
+  -H "App-Key: A-DEV-7944693530" \
+  -d '{
+    "eventName": "test_event",
+    "systemProps": {
+      "osName": "macOS",
+      "osVersion": "14.0",
+      "sdkVersion": "curl@1.0"
+    },
+    "props": {
+      "test": true
+    }
+  }'
+```
+
+### 使用动态时间戳 (Bash)
+
+```bash
+curl -k -X POST "https://localhost:5251/api/v0/event" \
+  -H "Content-Type: application/json" \
+  -H "App-Key: A-DEV-7944693530" \
+  -d '{
+    "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'",
+    "sessionId": "session-'$(uuidgen)'",
+    "eventName": "app_started",
+    "systemProps": {
+      "osName": "macOS",
+      "osVersion": "14.0",
+      "locale": "zh-CN",
+      "appVersion": "1.0.0",
+      "sdkVersion": "bash-curl@1.0"
+    }
+  }'
+```
+
+## 批量事件推送
+
+Aptabase 也支持批量推送多个事件：
+
+```
+POST /api/v0/events
+```
+
+```bash
+curl -X POST "https://your-aptabase-server/api/v0/events" \
+  -H "Content-Type: application/json" \
+  -H "App-Key: A-DEV-7944693530" \
+  -d '[
+    {
+      "eventName": "app_started",
+      "systemProps": {"sdkVersion": "curl@1.0"}
+    },
+    {
+      "eventName": "page_viewed",
+      "systemProps": {"sdkVersion": "curl@1.0"},
+      "props": {"page": "home"}
+    }
+  ]'
+```
+
+## 常见事件命名约定
+
+| 事件名称 | 说明 |
+|----------|------|
+| `app_started` | 应用启动 |
+| `app_backgrounded` | 应用进入后台 |
+| `app_foregrounded` | 应用回到前台 |
+| `page_viewed` | 页面浏览 |
+| `button_clicked` | 按钮点击 |
+| `feature_used` | 功能使用 |
+| `error_occurred` | 错误发生 |
+| `purchase_completed` | 购买完成 |
+
+## 注意事项
+
+1. **App Key 安全**: App Key 应妥善保管，不要提交到公开代码仓库
+2. **事件命名**: 建议使用 `snake_case` 格式命名事件
+3. **属性大小**: 单个事件的 props 不应过大，建议控制在 10KB 以内
+4. **频率限制**: 生产环境可能有速率限制，请参考服务器配置
+5. **时间戳**: 建议使用 UTC 时间戳，确保跨时区数据一致性

--- a/docs/IMPL-初始管理员账号密码配置.md
+++ b/docs/IMPL-初始管理员账号密码配置.md
@@ -1,0 +1,272 @@
+# 初始管理员账号密码配置实现方案
+
+## 修订记录
+
+| 版本 | 日期 | 修订内容 | 修订人 |
+|------|------|----------|--------|
+| v1.0 | 2024-12-30 | 初始版本创建 | AIMO开发团队 |
+
+## 1. 需求背景
+
+当前 Aptabase 系统仅支持以下登录方式：
+- **Magic Link**：通过邮件发送登录链接（需要邮件服务）
+- **OAuth**：GitHub/Google 第三方登录（需要配置 OAuth 应用）
+
+在本地开发或私有部署场景下，上述方式配置复杂。需要支持通过环境变量预置管理员账号密码，简化部署流程。
+
+## 2. 设计目标
+
+1. 通过环境变量配置初始管理员的邮箱和密码
+2. 支持密码登录方式
+3. 不修改现有数据库结构
+4. 保持与现有认证系统的兼容性
+5. 仅在配置了管理员凭据时启用密码登录
+
+## 3. 技术方案
+
+### 3.1 环境变量配置
+
+在 `EnvSettings.cs` 中添加管理员配置：
+
+| 环境变量 | 说明 | 示例 |
+|----------|------|------|
+| `ADMIN_EMAIL` | 管理员邮箱 | `admin@example.com` |
+| `ADMIN_PASSWORD` | 管理员密码 | `your-secure-password` |
+| `ADMIN_NAME` | 管理员名称（可选） | `Administrator` |
+
+### 3.2 模块设计
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        前端登录页面                          │
+│  ┌─────────────────┐    ┌─────────────────────────────────┐ │
+│  │  Magic Link 表单 │    │  密码登录表单（条件显示）        │ │
+│  └────────┬────────┘    └────────────────┬────────────────┘ │
+└───────────┼──────────────────────────────┼──────────────────┘
+            │                              │
+            ▼                              ▼
+┌───────────────────────┐    ┌─────────────────────────────────┐
+│ POST /api/_auth/signin │    │ POST /api/_auth/password-login  │
+│   (现有 Magic Link)    │    │        (新增端点)                │
+└───────────────────────┘    └────────────────┬────────────────┘
+                                              │
+                                              ▼
+                             ┌─────────────────────────────────┐
+                             │         AuthService             │
+                             │  ┌───────────────────────────┐  │
+                             │  │ ValidateAdminCredentials  │  │
+                             │  │ FindOrCreateAdminUser     │  │
+                             │  │ SignInAsync               │  │
+                             │  └───────────────────────────┘  │
+                             └─────────────────────────────────┘
+```
+
+### 3.3 后端实现
+
+#### 3.3.1 EnvSettings.cs 修改
+
+```csharp
+// 新增属性
+public string AdminEmail { get; private set; } = "";
+public string AdminPassword { get; private set; } = "";
+public string AdminName { get; private set; } = "Administrator";
+public bool IsAdminLoginEnabled => !string.IsNullOrEmpty(AdminEmail) && !string.IsNullOrEmpty(AdminPassword);
+
+// Load() 方法中添加
+AdminEmail = Get("ADMIN_EMAIL"),
+AdminPassword = Get("ADMIN_PASSWORD"),
+AdminName = Get("ADMIN_NAME").DefaultIfEmpty("Administrator"),
+```
+
+#### 3.3.2 AuthController.cs 新增端点
+
+```csharp
+public class PasswordLoginRequest
+{
+    [EmailAddress]
+    public string Email { get; set; } = "";
+
+    [Required]
+    [MinLength(6)]
+    public string Password { get; set; } = "";
+}
+
+[HttpGet("/api/_auth/password-login-enabled")]
+public IActionResult IsPasswordLoginEnabled()
+{
+    return Ok(new { enabled = _env.IsAdminLoginEnabled });
+}
+
+[HttpPost("/api/_auth/password-login")]
+[EnableRateLimiting("SignUp")]
+public async Task<IActionResult> PasswordLogin(
+    [FromBody] PasswordLoginRequest body,
+    CancellationToken cancellationToken)
+{
+    if (!_env.IsAdminLoginEnabled)
+        return NotFound(new { message = "Password login is not enabled" });
+
+    // 验证凭据
+    if (!string.Equals(body.Email, _env.AdminEmail, StringComparison.OrdinalIgnoreCase) ||
+        body.Password != _env.AdminPassword)
+    {
+        return Unauthorized(new { message = "Invalid credentials" });
+    }
+
+    // 查找或创建管理员用户
+    var user = await _authService.FindUserByEmailAsync(body.Email, cancellationToken);
+    if (user == null)
+    {
+        user = await _authService.CreateAccountAsync(
+            _env.AdminName,
+            body.Email,
+            cancellationToken);
+    }
+
+    await _authService.SignInAsync(user);
+    return Ok(new { });
+}
+```
+
+#### 3.3.3 安全考虑
+
+1. **速率限制**：复用 `SignUp` 策略（4次/小时）
+2. **密码不存储**：密码仅在环境变量中，不写入数据库
+3. **生产环境警告**：非开发环境启用时记录警告日志
+
+```csharp
+if (_env.IsAdminLoginEnabled && !_env.IsDevelopment)
+{
+    _logger.LogWarning("Admin password login is enabled in non-development environment");
+}
+```
+
+### 3.4 前端实现
+
+#### 3.4.1 登录页面修改
+
+文件：`src/webapp/features/auth/SignInPage.tsx`（或类似路径）
+
+```typescript
+// 查询是否启用密码登录
+const { data: passwordLoginConfig } = useQuery({
+  queryKey: ['password-login-enabled'],
+  queryFn: () => fetch('/api/_auth/password-login-enabled').then(r => r.json())
+});
+
+// 条件渲染密码登录表单
+{passwordLoginConfig?.enabled && (
+  <PasswordLoginForm onSuccess={() => navigate('/')} />
+)}
+```
+
+#### 3.4.2 密码登录表单组件
+
+```typescript
+function PasswordLoginForm({ onSuccess }: { onSuccess: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    const res = await fetch('/api/_auth/password-login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+
+    if (res.ok) {
+      onSuccess();
+    } else {
+      const data = await res.json();
+      setError(data.message || 'Login failed');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit">Sign In</button>
+    </form>
+  );
+}
+```
+
+### 3.5 配置示例
+
+#### launchSettings.json
+
+```json
+{
+  "profiles": {
+    "http": {
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "BASE_URL": "https://localhost:3000",
+        "DATABASE_URL": "Server=localhost;Port=5432;User Id=aptabase;Password=aptabase_pw;Database=aptabase",
+        "CLICKHOUSE_URL": "Host=localhost;Port=8123;Username=aptabase;Password=aptabase_pw",
+        "AUTH_SECRET": "E9F5C811CD74B9A3921A5DB502C0EDBE64B746000663AF04D91C249687FA969B",
+        "ADMIN_EMAIL": "admin@example.com",
+        "ADMIN_PASSWORD": "admin123",
+        "ADMIN_NAME": "Admin"
+      }
+    }
+  }
+}
+```
+
+#### Docker Compose
+
+```yaml
+services:
+  aptabase:
+    environment:
+      - ADMIN_EMAIL=admin@example.com
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - ADMIN_NAME=Administrator
+```
+
+## 4. 实现步骤
+
+| 步骤 | 文件 | 改动内容 |
+|------|------|----------|
+| 1 | `src/Features/EnvSettings.cs` | 添加管理员配置属性 |
+| 2 | `src/Features/Authentication/AuthController.cs` | 添加密码登录端点 |
+| 3 | `src/webapp/features/auth/*` | 添加密码登录表单 |
+| 4 | `src/Properties/launchSettings.example.json` | 添加配置示例 |
+
+## 5. 测试方案
+
+### 5.1 单元测试
+
+- 验证 `EnvSettings.IsAdminLoginEnabled` 逻辑
+- 验证凭据匹配逻辑
+
+### 5.2 集成测试
+
+| 场景 | 预期结果 |
+|------|----------|
+| 未配置管理员时访问密码登录端点 | 返回 404 |
+| 配置管理员后，正确凭据登录 | 返回 200，设置 Cookie |
+| 配置管理员后，错误凭据登录 | 返回 401 |
+| 首次登录自动创建用户 | 数据库中创建用户记录 |
+| 重复登录使用已有用户 | 不重复创建用户 |
+
+### 5.3 手动测试
+
+1. 配置环境变量启动后端
+2. 访问登录页面，确认显示密码登录表单
+3. 使用配置的邮箱密码登录
+4. 验证登录成功，跳转到首页
+
+## 6. 风险与注意事项
+
+1. **安全风险**：密码以明文存储在环境变量中，仅适用于开发/测试环境
+2. **生产环境**：建议生产环境使用 OAuth 或 Magic Link
+3. **密码强度**：建议添加密码强度提示，但不强制
+4. **向后兼容**：不配置时，系统行为与原来一致

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -75,6 +75,21 @@ public class EnvSettings
     // Variable Name: OAUTH_GOOGLE_CLIENT_SECRET
     public string OAuthGoogleClientSecret { get; private set; } = "";
 
+    // Admin account for password login (development/self-hosted)
+    // Variable Name: ADMIN_EMAIL
+    public string AdminEmail { get; private set; } = "";
+
+    // Admin password for password login
+    // Variable Name: ADMIN_PASSWORD
+    public string AdminPassword { get; private set; } = "";
+
+    // Admin display name
+    // Variable Name: ADMIN_NAME
+    public string AdminName { get; private set; } = "Administrator";
+
+    // Whether admin password login is enabled
+    public bool IsAdminLoginEnabled => !string.IsNullOrEmpty(AdminEmail) && !string.IsNullOrEmpty(AdminPassword);
+
     //  The following properties are derived from the other settings
     public bool IsManagedCloud => Region == "EU" || Region == "US";
     public bool IsBillingEnabled => IsManagedCloud || IsDevelopment;
@@ -117,6 +132,10 @@ public class EnvSettings
             OAuthGoogleClientId = Get("OAUTH_GOOGLE_CLIENT_ID"),
             OAuthGoogleClientSecret = Get("OAUTH_GOOGLE_CLIENT_SECRET"),
 
+            AdminEmail = Get("ADMIN_EMAIL"),
+            AdminPassword = Get("ADMIN_PASSWORD"),
+            AdminName = GetOrDefault("ADMIN_NAME", "Administrator"),
+
             // On the container, the etc directory is mounted at ./etc
             // But during development, it's at ../etc
             EtcDirectoryPath = Directory.Exists("./etc") ? "./etc" : "../etc"
@@ -136,6 +155,12 @@ public class EnvSettings
     private static string Get(string name)
     {
         return Environment.GetEnvironmentVariable(name) ?? "";
+    }
+
+    private static string GetOrDefault(string name, string defaultValue)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrEmpty(value) ? defaultValue : value;
     }
 
     private static int GetInt(string name)

--- a/src/webapp/features/auth/auth.ts
+++ b/src/webapp/features/auth/auth.ts
@@ -37,3 +37,33 @@ export async function signOut(): Promise<void> {
   await api.fetch("POST", "/_auth/signout");
   location.href = "/auth";
 }
+
+export async function isPasswordLoginEnabled(): Promise<boolean> {
+  const [status, response] = await api.fetch("GET", "/_auth/password-login-enabled");
+  if (status === 200) {
+    const data = await response.json();
+    return data.enabled === true;
+  }
+  return false;
+}
+
+export async function passwordLogin(email: string, password: string): Promise<{ success: boolean; message?: string }> {
+  const [status, response] = await api.fetch("POST", "/_auth/password-login", {
+    email,
+    password,
+  });
+
+  if (status === 200) {
+    return { success: true };
+  }
+
+  if (status === 401) {
+    return { success: false, message: "Invalid email or password" };
+  }
+
+  if (status === 404) {
+    return { success: false, message: "Password login is not enabled" };
+  }
+
+  return { success: false, message: "Login failed" };
+}


### PR DESCRIPTION
## Summary

- Add configurable admin password login for self-hosted deployments
- Add CLAUDE.md project documentation
- Add Event Ingestion API documentation with curl examples

## Changes

### Password Login Feature
- Add `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_NAME` environment variables to `EnvSettings.cs`
- Add `/api/_auth/password-login-enabled` endpoint to check if password login is enabled
- Add `/api/_auth/password-login` endpoint for credential validation
- Update `LoginPage.tsx` with login mode toggle (Magic Link / Password)
- Add `isPasswordLoginEnabled()` and `passwordLogin()` functions to `auth.ts`

### Documentation
- Add `CLAUDE.md` with project overview and development instructions
- Add `docs/EVENT_INGESTION_API.md` for event push API reference
- Add `docs/IMPL-初始管理员账号密码配置.md` implementation design document

## Test plan

- [ ] Set `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables
- [ ] Verify password login toggle appears on login page
- [ ] Test login with correct credentials
- [ ] Test login with incorrect credentials
- [ ] Verify event ingestion API works with curl examples