### PR TITLE
fixed email with starttls

### DIFF
--- a/src/Features/Notification/SmtpEmailClient.cs
+++ b/src/Features/Notification/SmtpEmailClient.cs
@@ -16,7 +16,7 @@ public class SmtpEmailClient : IEmailClient
     public async Task SendEmailAsync(string to, string subject, string templateName, Dictionary<string, string>? properties, CancellationToken cancellationToken)
     {
         using var smtp = new SmtpClient();
-        await smtp.ConnectAsync(_env.SmtpHost, _env.SmtpPort, IsTLSPort(_env.SmtpPort), cancellationToken);
+        await smtp.ConnectAsync(_env.SmtpHost, _env.SmtpPort, IsTLSPort(_env.SmtpPort) ? MailKit.Security.SecureSocketOptions.Auto : MailKit.Security.SecureSocketOptions.None, cancellationToken);
 
         if (!string.IsNullOrEmpty(_env.SmtpUsername))
             await smtp.AuthenticateAsync(_env.SmtpUsername, _env.SmtpPassword, cancellationToken);

--- a/tools/Aptabase.AppHost/Aptabase.AppHost.csproj
+++ b/tools/Aptabase.AppHost/Aptabase.AppHost.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.2.2" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.2.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.0" />
     <PackageReference Include="MailCatcher.Hosting" Version="1.0.0" />
     <PackageReference Include="ClickHouse.Hosting" Version="1.0.0" />
   </ItemGroup>

--- a/tools/Aptabase.AppHost/Program.cs
+++ b/tools/Aptabase.AppHost/Program.cs
@@ -22,7 +22,7 @@ var api = builder.AddProject<Projects.Aptabase>("api")
        .WithReference(mailcatcher)
        .WithExternalHttpEndpoints();
 
-builder.AddNpmApp("frontend", "../../src", scriptName: "dev")
+builder.AddJavaScriptApp("frontend", "../../src", runScriptName: "dev")
     .WithReference(api)
     .WithHttpsEndpoint(port: 3000, isProxied: false)
     .WithExternalHttpEndpoints();


### PR DESCRIPTION
- fix issues when smtp uses 587 with starttls
- updated Aspire to 13.1.0 removing dependency on deprecated Aspire workload