### PR TITLE
Add self-hosting guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/Properties/*
 !src/Properties/launchSettings.example.json
 /tests/IntegrationTests/Properties/launchSettings.json
 /tests/UnitTests/Properties/launchSettings.json
+.env

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The easiest and quickest way to get started. A fully managed service by the crea
 
 You can also host Aptabase on your servers. It's free, but you are responsible for maintenance and updates.
 
-[Learn how →](https://github.com/aptabase/self-hosting).
+[Learn how →](./docs/self-host/README.md).
 
 ## 🛠️ Contributing
 

--- a/docs/self-host/.env.example
+++ b/docs/self-host/.env.example
@@ -1,0 +1,24 @@
+# Generate secrets with:
+# openssl rand -base64 48
+
+# Domain
+BASE_URL=https://analytics.yourdomain.com
+
+# Secrets
+AUTH_SECRET=PASTE_GENERATED_SECRET_HERE
+
+# Postgres
+POSTGRES_USER=aptabase
+POSTGRES_PASSWORD=PASTE_GENERATED_PASSWORD_HERE
+POSTGRES_DB=aptabase
+
+# Clickhouse
+CLICKHOUSE_USER=aptabase
+CLICKHOUSE_PASSWORD=PASTE_GENERATED_PASSWORD_HERE
+
+# Caddy
+CADDY_DOMAIN=analytics.yourdomain.com
+
+# Aptabase (Get from dashboard later)
+APTABASE_APP_KEY=A-SH-YOUR-APP-KEY-HERE
+APTABASE_BASE_URL=https://analytics.yourdomain.com

--- a/docs/self-host/Caddyfile
+++ b/docs/self-host/Caddyfile
@@ -1,0 +1,20 @@
+{$CADDY_DOMAIN} {
+    encode gzip
+
+    # Prefer Cloudflare real client IP if present,
+    # otherwise fall back to direct client IP
+    map {http.request.header.CF-Connecting-IP} {real_client_ip} {
+        ""      {remote_host}                     # non-Cloudflare / direct traffic
+        default {http.request.header.CF-Connecting-IP}  # Cloudflare traffic
+    }
+
+    reverse_proxy aptabase:8080 {
+        # Forward a single clean client IP (no port, no duplicates)
+        header_up X-Forwarded-For {real_client_ip}
+        header_up X-Real-IP {real_client_ip}
+
+        # Required for correct HTTPS + cookies
+        header_up X-Forwarded-Proto https
+        header_up Host {host}
+    }
+}

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -1,0 +1,134 @@
+# Self-Hosting Aptabase
+
+Short guide to self-host **Aptabase** with Docker + Caddy + HTTPS.
+
+This is meant to be simple and fire-and-forget.
+
+---
+
+## 1. Server
+
+Rent a small VPS.  
+Example that works well and is cheap:
+
+OVHcloud VPS-1  
+4 vCPU, **8 GB RAM**, 75 GB SSD (~$4.20/month)
+
+Important: Aptabase uses **ClickHouse** for events.  
+1–2 GB RAM will not work reliably.  
+8 GB RAM is the safe minimum and still cheap.
+
+---
+
+## 2. Install Docker
+
+Install Docker on Ubuntu:
+https://docs.docker.com/engine/install/ubuntu/
+
+Check:
+
+```console
+docker --version
+docker compose version
+```
+
+---
+
+## 3. Install uv (used for helper script)
+
+https://docs.astral.sh/uv/getting-started/installation/
+
+```console
+uv --version
+```
+
+---
+
+## 4. Domain + HTTPS (required)
+
+Buy a domain (Cloudflare is recommended, ~$5–10/year):
+https://www.cloudflare.com/
+
+This is important because Aptabase auth cookies use `Secure=true`  
+and require HTTPS.
+
+Create DNS record:
+
+- analytics.yourdomain.com → server IP
+- Proxy ON (orange cloud)
+
+---
+
+## 5. Environment (.env)
+
+Copy the example env file and edit it:
+
+```console
+cp .env.example .env
+```
+
+Generate a strong random secret:
+
+```console
+openssl rand -base64 48
+```
+
+Then set your values in the `.env` file.
+
+---
+
+## 6. Docker Compose
+
+Use Docker Compose with:
+
+- Caddy (HTTPS + reverse proxy)
+- Postgres (users)
+- ClickHouse (events)
+- Aptabase app
+
+Bring everything up:
+
+```console
+mkdir -p data/postgres data/clickhouse
+docker compose up -d
+```
+
+Caddy will automatically issue HTTPS certificates.
+
+---
+
+## 7. Verify
+
+Open in browser:
+https://analytics.yourdomain.com
+
+If it loads, you are done.
+
+---
+
+## 8. Create one-time login link (optional)
+
+On the server, use this helper script to generate a magic login URL:
+
+```console
+uv run create_auth_link.py \
+ --name YourName \
+ --email you@example.com
+```
+
+The printed link is single-use and short-lived.
+
+## 9. Send a test event
+
+To verify everything works end-to-end, send a test event.
+
+Make sure to set the `BASE_URL` and `APTABASE_APP_KEY` in the `.env` file.
+
+```console
+uv run create_test_event.py
+```
+
+---
+
+That’s it.
+This setup is stable, cheap, and production-ready.

--- a/docs/self-host/compose.yml
+++ b/docs/self-host/compose.yml
@@ -1,0 +1,58 @@
+services:
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - CADDY_DOMAIN=${CADDY_DOMAIN}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - aptabase
+
+  aptabase_db:
+    image: postgres:15-alpine
+    container_name: aptabase_db
+    restart: always
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+
+  aptabase_events_db:
+    image: clickhouse/clickhouse-server:23.8.4.69-alpine
+    container_name: aptabase_events_db
+    restart: always
+    volumes:
+      - ./data/clickhouse:/var/lib/clickhouse
+    environment:
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  aptabase:
+    image: ghcr.io/aptabase/aptabase:main
+    container_name: aptabase_app
+    restart: always
+    depends_on:
+      - aptabase_db
+      - aptabase_events_db
+    environment:
+      BASE_URL: ${BASE_URL}
+      AUTH_SECRET: ${AUTH_SECRET}
+      DATABASE_URL: Server=aptabase_db;Port=5432;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Database=${POSTGRES_DB}
+      CLICKHOUSE_URL: Host=aptabase_events_db;Port=8123;Username=${CLICKHOUSE_USER};Password=${CLICKHOUSE_PASSWORD}
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docs/self-host/create_auth_link.py
+++ b/docs/self-host/create_auth_link.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyjwt==2.11.0",
+#     "python-dotenv==1.0.1",
+# ]
+# ///
+
+"""
+Usage:
+uv run auth_link.py --name YourName --email you@example.com
+"""
+
+import argparse
+import os
+import time
+from urllib.parse import quote
+
+import jwt
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def require_env(key: str) -> str:
+    value = os.environ.get(key)
+    if not value:
+        raise SystemExit(f"Missing {key} in .env")
+    return value
+
+
+def build_issuer(region: str) -> str:
+    return f"aptabase-{region.strip().lower()}"
+
+
+def build_token(
+    auth_secret: str,
+    issuer: str,
+    name: str,
+    email: str,
+    expires_in_minutes: int,
+) -> str:
+    now = int(time.time())
+    payload = {
+        "type": "Register",
+        "name": name,
+        "email": email,
+        "exp": now + (expires_in_minutes * 60),
+        "iat": now,
+        "iss": issuer,
+    }
+    return jwt.encode(payload, auth_secret, algorithm="HS256")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--expires-in-minutes", type=int, default=10)
+    args = parser.parse_args()
+
+    if args.expires_in_minutes <= 0 or args.expires_in_minutes > 15:
+        raise SystemExit("--expires-in-minutes must be between 1 and 15")
+
+    base_url = require_env("BASE_URL")
+    auth_secret = require_env("AUTH_SECRET")
+    region = os.environ.get("APTABASE_REGION", "SH")
+
+    issuer = build_issuer(region)
+    token = build_token(
+        auth_secret=auth_secret,
+        issuer=issuer,
+        name=args.name,
+        email=args.email,
+        expires_in_minutes=args.expires_in_minutes,
+    )
+
+    url = f"{base_url.rstrip('/')}/api/_auth/continue?token={quote(token, safe='')}"
+    print(url)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/self-host/create_test_event.py
+++ b/docs/self-host/create_test_event.py
@@ -1,0 +1,35 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "aptabase==0.1.0",
+#     "python-dotenv==1.2.1",
+# ]
+# ///
+
+import asyncio
+import os
+
+from aptabase import Aptabase
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+async def main() -> None:
+    app_key = os.getenv("APTABASE_APP_KEY")
+    base_url = os.getenv("APTABASE_BASE_URL")
+    print(f"Config: app_key={app_key}, base_url={base_url}")
+
+    async with Aptabase(app_key, base_url=base_url) as client:
+        await client.track(
+            "test_event",
+            {
+                "source": "self_host_test",
+                "ok": True,
+            },
+        )
+        await client.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Self-hosting Aptabase with the current docs took me many, many hours to get right.

There are a lot of small but important details involved (ClickHouse memory needs, HTTPS, cookies with Secure=true, BASE_URL, reverse proxy, etc.), and it was easy to miss things or end up with a setup that almost works.

This PR adds a short, fire-and-forget self-hosting guide that documents a working, production-ready setup using:
- Docker Compose
- Caddy for automatic HTTPS
- Postgres + ClickHouse
- A real domain (required for auth to work correctly)

I believe the main repo is the best place for this guide, since self-hosting is a core use case and having an official, minimal reference can save others a lot of time.

The goal here is not to cover every option, but to provide one clear path that is known to work.
