### PR TITLE
Fix selfhosting issues

### DIFF
--- a/src/Features/Authentication/AuthController.cs
+++ b/src/Features/Authentication/AuthController.cs
@@ -65,13 +65,29 @@ public class AuthController : Controller
     [HttpGet("/api/_auth/github")]
     public IActionResult GitHub()
     {
+        if (string.IsNullOrWhiteSpace(_env.OAuthGitHubClientId) || string.IsNullOrWhiteSpace(_env.OAuthGitHubClientSecret))
+            return NotFound(new { });
+
         return Challenge(new AuthenticationProperties { RedirectUri = $"{_env.SelfBaseUrl}/" }, "github");
     }
 
     [HttpGet("/api/_auth/google")]
     public IActionResult Google()
     {
+        if (string.IsNullOrWhiteSpace(_env.OAuthGoogleClientId) || string.IsNullOrWhiteSpace(_env.OAuthGoogleClientSecret))
+            return NotFound(new { });
+
         return Challenge(new AuthenticationProperties { RedirectUri = $"{_env.SelfBaseUrl}/" }, "google");
+    }
+
+    [HttpGet("/api/_auth/providers")]
+    public IActionResult Providers()
+    {
+        return Ok(new
+        {
+            github = !string.IsNullOrWhiteSpace(_env.OAuthGitHubClientId) && !string.IsNullOrWhiteSpace(_env.OAuthGitHubClientSecret),
+            google = !string.IsNullOrWhiteSpace(_env.OAuthGoogleClientId) && !string.IsNullOrWhiteSpace(_env.OAuthGoogleClientSecret)
+        });
     }
 
     [HttpGet("/api/_auth/me")]

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -99,7 +99,7 @@ public class EnvSettings
         {
             IsDevelopment = isDevelopment,
             Region = region,
-            SelfBaseUrl = MustGet("BASE_URL"),
+            SelfBaseUrl = NormalizeBaseUrl(MustGet("BASE_URL")),
             ConnectionString = GetOrNull("ConnectionStrings__postgresdb") ?? MustGet("DATABASE_URL"),
             ClickHouseConnectionString = GetOrNull("ConnectionStrings__clickhousedb") ?? Get("CLICKHOUSE_URL"),
             TinybirdBaseUrl = Get("TINYBIRD_BASE_URL"),
@@ -152,5 +152,25 @@ public class EnvSettings
     private static string MustGet(string name)
     {
         return Environment.GetEnvironmentVariable(name) ?? throw new Exception($"Missing {name} environment variable");
+    }
+
+    private static string NormalizeBaseUrl(string baseUrl)
+    {
+        var value = (baseUrl ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+
+        if (!value.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !value.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            value = $"https://{value}";
+        }
+
+        value = value.TrimEnd('/');
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out _))
+            throw new Exception("BASE_URL must be an absolute URL, e.g. https://analytics.yourdomain.com");
+
+        return value;
     }
 }

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -59,6 +59,9 @@ public class EnvSettings
     // Variable Name: SMTP_FROM_ADDRESS
     public string SmtpFromAddress { get; private set; } = "";
 
+    // OAuth will be enabled if at least one pair is configured.
+    // Set this callback: https://YOUR_BASE_URL/api/_auth/github/callback
+
     // The GitHub Client ID for OAuth
     // Variable Name: OAUTH_GITHUB_CLIENT_ID
     public string OAuthGitHubClientId { get; private set; } = "";

--- a/src/webapp/features/auth/LoginPage.tsx
+++ b/src/webapp/features/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { requestSignInLink } from "@features/auth";
+import { getOAuthProviders, requestSignInLink } from "@features/auth";
 import { Page } from "@components/Page";
 import { useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
@@ -7,10 +7,10 @@ import { LegalNotice } from "./LegalNotice";
 import { RegionSwitch } from "./RegionSwitch";
 import { SignInWithGitHub } from "./SignInWithGitHub";
 import { SignInWithGoogle } from "./SignInWithGoogle";
-import { isOAuthEnabled } from "@features/env";
 import { Logo } from "./Logo";
 import { Button } from "@components/Button";
 import { TextInput } from "@components/TextInput";
+import { useQuery } from "@tanstack/react-query";
 
 type FormStatus = "idle" | "loading" | "success" | "notfound";
 
@@ -66,6 +66,16 @@ export function Component() {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<FormStatus>("idle");
 
+  const { data: providers } = useQuery({
+    queryKey: ["oauthProviders"],
+    queryFn: getOAuthProviders,
+    staleTime: Infinity,
+  });
+
+  const showGitHub = !!providers?.github;
+  const showGoogle = !!providers?.google;
+  const showOAuth = showGitHub || showGoogle;
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setStatus("loading");
@@ -87,11 +97,11 @@ export function Component() {
       </div>
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="py-8 px-4 sm:rounded-lg sm:px-10">
-          {isOAuthEnabled && (
+          {showOAuth && (
             <>
               <div className="space-y-2">
-                <SignInWithGitHub />
-                <SignInWithGoogle />
+                {showGitHub && <SignInWithGitHub />}
+                {showGoogle && <SignInWithGoogle />}
               </div>
 
               <div className="relative my-4">

--- a/src/webapp/features/auth/RegisterPage.tsx
+++ b/src/webapp/features/auth/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import { requestRegisterLink } from "@features/auth";
+import { getOAuthProviders, requestRegisterLink } from "@features/auth";
 import { Page } from "@components/Page";
 import { useState } from "react";
 import { Link } from "react-router-dom";
@@ -7,10 +7,10 @@ import { LegalNotice } from "./LegalNotice";
 import { RegionSwitch } from "./RegionSwitch";
 import { SignInWithGitHub } from "./SignInWithGitHub";
 import { SignInWithGoogle } from "./SignInWithGoogle";
-import { isOAuthEnabled } from "@features/env";
 import { Logo } from "./Logo";
 import { Button } from "@components/Button";
 import { TextInput } from "@components/TextInput";
+import { useQuery } from "@tanstack/react-query";
 
 type FormStatus = "idle" | "loading" | "success";
 
@@ -40,6 +40,16 @@ export function Component() {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<FormStatus>("idle");
 
+  const { data: providers } = useQuery({
+    queryKey: ["oauthProviders"],
+    queryFn: getOAuthProviders,
+    staleTime: Infinity,
+  });
+
+  const showGitHub = !!providers?.github;
+  const showGoogle = !!providers?.google;
+  const showOAuth = showGitHub || showGoogle;
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setStatus("loading");
@@ -58,11 +68,11 @@ export function Component() {
       </div>
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="py-8 px-4 sm:rounded-lg sm:px-10">
-          {isOAuthEnabled && (
+          {showOAuth && (
             <>
               <div className="space-y-2">
-                <SignInWithGitHub />
-                <SignInWithGoogle />
+                {showGitHub && <SignInWithGitHub />}
+                {showGoogle && <SignInWithGoogle />}
               </div>
               <div className="relative my-4">
                 <div className="absolute inset-0 flex items-center" aria-hidden="true">

--- a/src/webapp/features/auth/auth.ts
+++ b/src/webapp/features/auth/auth.ts
@@ -8,6 +8,15 @@ export type UserAccount = {
   avatarUrl: string;
 };
 
+export type OAuthProviders = {
+  github: boolean;
+  google: boolean;
+};
+
+export async function getOAuthProviders(): Promise<OAuthProviders> {
+  return await api.get<OAuthProviders>("/_auth/providers");
+}
+
 export async function requestSignInLink(email: string): Promise<boolean> {
   const [status, response] = await api.fetch("POST", "/_auth/signin", {
     email,


### PR DESCRIPTION
## 1. Fixed OAuth buttons not showing on auth pages.

**Issue:** The configs for each were never passed to the frontend, unless `isManagedCloud` was true. Which it isn't for `SH`.

**Fix:** I updated the auth page to dynamically show either the Google or Github OAuth button if a pair is configured, instead of relying on this:
```ts
export const isOAuthEnabled = isManagedCloud || isDevelopment;
```

## 2. Fixed OAuth callback and Magic Link returning a 404 page

**Issue:** Tries to construct the redirect, but incorrectly builds `/api/_auth/github/BASE_URL/auth?...`, which returns 404.

**Fix:** Fixed BASE_URL normalization within EnvSettings.cs by removing `http://` or `https://` so the correct URL is passed.

