### PR TITLE
Prioritize Cloudflare client IP

### DIFF
--- a/src/Extensions/HttpExtensions.cs
+++ b/src/Extensions/HttpExtensions.cs
@@ -4,6 +4,9 @@ public static class HttpContextExtensions
 {
     public static string ResolveClientIpAddress(this HttpContext httpContext)
     {
+        if (httpContext.Request.Headers.TryGetValue("Cf-Connecting-Ip", out var cfIp) && !string.IsNullOrEmpty(cfIp))
+            return cfIp.ToString();
+
         if (httpContext.Request.Headers.TryGetValue("X-Real-Ip", out var ip) && !string.IsNullOrEmpty(ip))
             return ip.ToString();
 

--- a/tests/UnitTests/Features/Ingestion/HttpExtensionsTests.cs
+++ b/tests/UnitTests/Features/Ingestion/HttpExtensionsTests.cs
@@ -5,6 +5,21 @@ namespace Aptabase.UnitTests.Features.Ingestion;
 
 public class HttpExtensionsTests
 {
+    [Fact]
+    public void ResolveClientIpAddressPrioritizesCfConnectingIp()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append("Cf-Connecting-Ip", "203.0.113.1");
+        context.Request.Headers.Append("X-Real-Ip", "203.0.113.2");
+        context.Request.Headers.Append("X-Forwarded-For", "203.0.113.3");
+        context.Request.Headers.Append("CloudFront-Viewer-Address", "203.0.113.4:443");
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.5");
+
+        var value = context.ResolveClientIpAddress();
+
+        Assert.Equal("203.0.113.1", value);
+    }
+
     [Theory]
     [InlineData(new string[] {}, "")]
     [InlineData(new string[] {""}, "")]


### PR DESCRIPTION
Support domains behind Cloudflare Proxy.

Prioritize resolving the client IP from CF-Connecting-IP, because X-Real-IP may contain a Cloudflare IP.