### PR TITLE
feat: add optional CLIENT_IP_HEADER to resolve client IP from a confi…

### DIFF
--- a/src/Extensions/HttpExtensions.cs
+++ b/src/Extensions/HttpExtensions.cs
@@ -2,8 +2,15 @@ namespace Microsoft.AspNetCore.Http;
 
 public static class HttpContextExtensions
 {
-    public static string ResolveClientIpAddress(this HttpContext httpContext)
+    public static string ResolveClientIpAddress(this HttpContext httpContext, string clientIpHeader = "")
     {
+        // Only trust this header when the instance is behind a trusted reverse proxy/CDN,
+        // since its value is used as-is with no further validation
+        if (!string.IsNullOrEmpty(clientIpHeader) &&
+            httpContext.Request.Headers.TryGetValue(clientIpHeader, out var configuredIp) &&
+            !string.IsNullOrEmpty(configuredIp))
+            return configuredIp.ToString();
+
         if (httpContext.Request.Headers.TryGetValue("X-Real-Ip", out var ip) && !string.IsNullOrEmpty(ip))
             return ip.ToString();
 

--- a/src/Features/EnvSettings.cs
+++ b/src/Features/EnvSettings.cs
@@ -14,6 +14,12 @@ public class EnvSettings
     // Variable Name: DATABASE_URL
     public string ConnectionString { get; private set; } = "";
 
+    // The name of an HTTP header that carries the real client IP address, set by a trusted reverse proxy/CDN
+    // Only set this if the app is behind a proxy you trust, since the header value is used as-is
+    // E.g: CF-Connecting-IP
+    // Variable Name: CLIENT_IP_HEADER
+    public string ClientIpHeader { get; private set; } = "";
+
     // The full connection string to ClickHouse using .NET format
     // E.g: Host=my.clickhouse;Protocol=https;Port=12345;Username=user
     // Variable Name: CLICKHOUSE_URL
@@ -98,6 +104,7 @@ public class EnvSettings
             Region = region,
             SelfBaseUrl = MustGet("BASE_URL"),
             ConnectionString = GetOrNull("ConnectionStrings__postgresdb") ?? MustGet("DATABASE_URL"),
+            ClientIpHeader = Get("CLIENT_IP_HEADER"),
             ClickHouseConnectionString = GetOrNull("ConnectionStrings__clickhousedb") ?? Get("CLICKHOUSE_URL"),
             TinybirdBaseUrl = Get("TINYBIRD_BASE_URL"),
             TinybirdToken = Get("TINYBIRD_TOKEN"),

--- a/src/Features/GeoIP/DatabaseGeoClient.cs
+++ b/src/Features/GeoIP/DatabaseGeoClient.cs
@@ -5,16 +5,18 @@ namespace Aptabase.Features.GeoIP;
 public class DatabaseGeoClient : GeoIPClient
 {
     private readonly DatabaseReader _db;
+    private readonly EnvSettings _env;
 
     public DatabaseGeoClient(EnvSettings env)
         : base(env)
     {
+        _env = env;
         _db = new DatabaseReader(Path.Combine(env.EtcDirectoryPath, "geoip/GeoLite2-City.mmdb"));
     }
 
     public override GeoLocation GetClientLocation(HttpContext httpContext)
     {
-        var ip = httpContext.ResolveClientIpAddress();
+        var ip = httpContext.ResolveClientIpAddress(_env.ClientIpHeader);
         
         if (string.IsNullOrEmpty(ip))
             return GeoLocation.Empty;

--- a/src/Features/Ingestion/EventsController.cs
+++ b/src/Features/Ingestion/EventsController.cs
@@ -14,15 +14,18 @@ public class EventsController : Controller
     private readonly IIngestionCache _cache;
     private readonly IEventBuffer _buffer;
     private readonly GeoIPClient _geoIP;
+    private readonly EnvSettings _env;
 
     public EventsController(IIngestionCache cache,
                             IEventBuffer buffer,
                             GeoIPClient geoIP,
+                            EnvSettings env,
                             ILogger<EventsController> logger)
     {
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
         _geoIP = geoIP ?? throw new ArgumentNullException(nameof(geoIP));
+        _env = env ?? throw new ArgumentNullException(nameof(env));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -72,7 +75,7 @@ public class EventsController : Controller
         if (!isWeb)
             userAgent = $"{body.SystemProps.OSName}/{body.SystemProps.OSVersion} {body.SystemProps.EngineName}/{body.SystemProps.EngineVersion} {body.SystemProps.Locale}";
 
-        var clientIp = HttpContext.ResolveClientIpAddress();
+        var clientIp = HttpContext.ResolveClientIpAddress(_env.ClientIpHeader);
         var location = _geoIP.GetClientLocation(HttpContext);
         var trackingEvent = NewTrackingEvent(app.Id, location.CountryCode, location.RegionName, clientIp, userAgent ?? "", body);
         _buffer.Add(ref trackingEvent);
@@ -119,7 +122,7 @@ public class EventsController : Controller
         if (app.IsLocked) 
             return BadRequest($"Owner account is locked.");
 
-        var clientIp = HttpContext.ResolveClientIpAddress();
+        var clientIp = HttpContext.ResolveClientIpAddress(_env.ClientIpHeader);
         var location = _geoIP.GetClientLocation(HttpContext);
         var trackingEvents = validEvents.Select(e => NewTrackingEvent(app.Id, location.CountryCode, location.RegionName, clientIp, userAgent ?? "", e));
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -93,7 +93,7 @@ public partial class Program
             c.RejectionStatusCode = 429;
 
             c.AddPolicy("SignUp", httpContext => RateLimitPartition.GetFixedWindowLimiter(
-                httpContext.ResolveClientIpAddress(),
+                httpContext.ResolveClientIpAddress(appEnv.ClientIpHeader),
                 partition => new FixedWindowRateLimiterOptions
                 {
                     AutoReplenishment = true,
@@ -103,7 +103,7 @@ public partial class Program
             );
 
             c.AddPolicy("Stats", httpContext => RateLimitPartition.GetFixedWindowLimiter(
-                httpContext.ResolveClientIpAddress(),
+                httpContext.ResolveClientIpAddress(appEnv.ClientIpHeader),
                 partition => new FixedWindowRateLimiterOptions
                 {
                     AutoReplenishment = true,
@@ -113,7 +113,7 @@ public partial class Program
             );
 
             c.AddPolicy("EventIngestion", httpContext => RateLimitPartition.GetFixedWindowLimiter(
-                httpContext.ResolveClientIpAddress(),
+                httpContext.ResolveClientIpAddress(appEnv.ClientIpHeader),
                 partition => new FixedWindowRateLimiterOptions
                 {
                     AutoReplenishment = true,
@@ -123,7 +123,7 @@ public partial class Program
             );
 
             c.AddPolicy("FeatureFlags", httpContext => RateLimitPartition.GetFixedWindowLimiter(
-                httpContext.ResolveClientIpAddress(),
+                httpContext.ResolveClientIpAddress(appEnv.ClientIpHeader),
                 partition => new FixedWindowRateLimiterOptions
                 {
                     AutoReplenishment = true,

--- a/tests/UnitTests/Features/Ingestion/HttpExtensionsTests.cs
+++ b/tests/UnitTests/Features/Ingestion/HttpExtensionsTests.cs
@@ -20,4 +20,42 @@ public class HttpExtensionsTests
         var value = context.ResolveClientIpAddress();
         Assert.Equal(expected, value);
     }
+
+    [Fact]
+    public void ResolveClientIpAddress_WithClientIpHeader_TakesPriorityOverEverythingElse()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append("CF-Connecting-IP", new StringValues("203.0.113.1"));
+        context.Request.Headers.Append("X-Real-Ip", new StringValues("10.0.0.1"));
+        context.Request.Headers.Append("X-Forwarded-For", new StringValues("10.0.0.2"));
+
+        var value = context.ResolveClientIpAddress("CF-Connecting-IP");
+
+        Assert.Equal("203.0.113.1", value);
+    }
+
+    [Fact]
+    public void ResolveClientIpAddress_WithClientIpHeaderMissingFromRequest_FallsBackToExistingLogic()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append("X-Real-Ip", new StringValues("10.0.0.1"));
+
+        var value = context.ResolveClientIpAddress("CF-Connecting-IP");
+
+        Assert.Equal("10.0.0.1", value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ResolveClientIpAddress_WithoutClientIpHeaderConfigured_BehavesExactlyAsBefore(string? clientIpHeader)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Append("CF-Connecting-IP", new StringValues("203.0.113.1"));
+        context.Request.Headers.Append("X-Real-Ip", new StringValues("10.0.0.1"));
+
+        var value = context.ResolveClientIpAddress(clientIpHeader ?? "");
+
+        Assert.Equal("10.0.0.1", value);
+    }
 }


### PR DESCRIPTION
### Problem

On self-hosted instances behind a reverse proxy or CDN, every event is geolocated to the **proxy/edge IP** instead of the visitor. Behind Cloudflare, for example, the real client IP arrives in `CF-Connecting-IP`, but `ResolveClientIpAddress` only reads `X-Real-Ip` / `X-Forwarded-For` / `CloudFront-Viewer-Address`, which the reverse proxy fills with the CloudFlare edge IP. Result: all traffic collapses to a single wrong country. 

### Change

Add an optional `CLIENT_IP_HEADER` environment variable:

- When **set** (e.g. `CF-Connecting-IP`), `ResolveClientIpAddress` returns that header's value first, before the existing checks.
- When **unset or empty**, behavior is **identical to today** — fully backward-compatible.

It's generic on purpose (works for Cloudflare, other CDNs, or any trusted proxy) rather than hardcoding a vendor. The header is passed explicitly from `EnvSettings.ClientIpHeader` to every call site (GeoIP resolution, event ingestion, and the rate-limiter partitions).

### How to enable
CLIENT_IP_HEADER=CF-Connecting-IP

### Security note
The header value is trusted as-is (same as the existing `X-Real-Ip` / `X-Forwarded-For` handling), so it should only be set when the instance is behind a proxy you trust. A `TRUSTED_PROXIES` allowlist would be a natural future hardening.

### Tests
Added unit tests in `HttpExtensionsTests` covering: configured header takes priority; falls back to the existing logic when the header is absent; and unset/empty leaves current behavior unchanged. Full suite: **62/62 passing**.

### Note on the diff size `src/Program.cs` shows as a large diff, but that's **only a CRLF→LF line ending normalization** — it was the only CRLF-encoded file in the repo (`core.autocrlf=input`, no `.gitattributes`), so git normalizes it on commit regardless. Its only *logical* change is the 4 rate-limiter call sites now passing `appEnv.ClientIpHeader`.