### PR TITLE
Fix dashboard event links after reload

### DIFF
--- a/src/webapp/features/analytics/dashboard/EventWidget.tsx
+++ b/src/webapp/features/analytics/dashboard/EventWidget.tsx
@@ -25,6 +25,7 @@ export function EventWidget(props: Props) {
           key="events"
           title="Events"
           searchParamKey="eventName"
+          pathname={`/${props.appId}/`}
           defaultFormat="absolute"
           valueLabel="Count"
         />

--- a/src/webapp/features/analytics/dashboard/TopNChart.tsx
+++ b/src/webapp/features/analytics/dashboard/TopNChart.tsx
@@ -26,6 +26,7 @@ type Props = {
   isLoading?: boolean;
   isError?: boolean;
   searchParamKey?: string;
+  pathname?: string;
   externalLink?: (item: Item) => string;
   refetch?: (options?: RefetchOptions | undefined) => Promise<QueryObserverResult<any, Error>>;
 };
@@ -76,6 +77,7 @@ export function TopNChart(props: Props) {
             format={format}
             percentage={Math.round(item.value) / total}
             searchParamKey={props.searchParamKey}
+            pathname={props.pathname}
             externalLink={props.externalLink?.(item)}
           >
             <div className="px-2">{renderRow(item)}</div>
@@ -94,6 +96,7 @@ type TopNRowProps = {
   format: "absolute" | "percentage";
   children: React.ReactNode;
   searchParamKey?: string;
+  pathname?: string;
   externalLink?: string;
 };
 
@@ -104,13 +107,14 @@ function TopNRow(props: TopNRowProps) {
   } else {
     const targetUrl = new URL(window.location.href);
 
-    targetUrlStr = window.location.href;
-    if (props.searchParamKey) {
-      if (props.searchParamKey) {
-        targetUrl.searchParams.set(props.searchParamKey, props.item.name);
-      }
-      targetUrlStr = targetUrl.toString();
+    if (props.pathname) {
+      targetUrl.pathname = props.pathname;
     }
+
+    if (props.searchParamKey) {
+      targetUrl.searchParams.set(props.searchParamKey, props.item.name);
+    }
+    targetUrlStr = targetUrl.toString();
   }
 
   const content = (


### PR DESCRIPTION
Fixes #176.

## Summary

- make event links target the app dashboard explicitly
- preserve the current query string while updating the event filter
- avoid retaining a tab-specific pathname after direct navigation or reload

## Validation

- npm run build (TypeScript and production Vite build)
- git diff --check

OpenAI Codex assisted with implementation and validation; I reviewed the final diff and build output.